### PR TITLE
Update Spellcheck.cs

### DIFF
--- a/28.09.22 Simple Spellcheck/neilh/SimpleSpellcheck/SimpleSpellcheck/Spellcheck.cs
+++ b/28.09.22 Simple Spellcheck/neilh/SimpleSpellcheck/SimpleSpellcheck/Spellcheck.cs
@@ -12,7 +12,7 @@ namespace SimpleSpellcheck
 {
     public class Spellcheck
     {
-        private Dictionary<string, int> _dictionary;
+        private Dictionary<string, int>? _dictionary;
         private string _alphabet = "abcdefghijklmnopqrstuvwxyz";
 
         public IEnumerable<string> FindUnrecognisedWords(string input)


### PR DESCRIPTION
Should probably make _dictionary nullable now to avoid code null check warnings. I forgot this on the last PR.