### PR TITLE
Add SKPR test. Refactor tests. Fix SKPR instruction base.

### DIFF
--- a/Chip-8 Challenge/src/CHIP-8 Tests/InstructionTests.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Tests/InstructionTests.cs
@@ -7,8 +7,22 @@ namespace CHIP_8_Tests
     [TestFixture]
     public class InstructionTests
     {
+        public string WINKEY_1 = "1";
+        public Nibble KEYPAD_0 = 0;
 
         public VM VM { get; set; }
+        
+        public void KeyOp(bool down, string keyCode)
+        {
+            if (down)
+            {
+                VM.Keypad.WindowsKeyDown(keyCode);
+            }
+            else
+            {
+                VM.Keypad.WindowsKeyUp(keyCode);
+            }
+        }
 
         [SetUp]
         public void Setup()
@@ -21,42 +35,41 @@ namespace CHIP_8_Tests
         {
         }
 
-        [TestCase(true)]
-        [TestCase(false)]
-        public void SKUP(bool keyUp)
+        [TestCase(true, ExpectedResult = 2)]
+        [TestCase(false, ExpectedResult = 0)]
+        public int SKUP(bool keyUp)
         {
-            Tribble pc = VM.PC;
+            KeyOp(!keyUp, WINKEY_1);
 
-            if (keyUp)
-            {
-                VM.Keypad.WindowsKeyUp("1");
-            }
-            else
-            {
-                VM.Keypad.WindowsKeyDown("1");
-            }
-
-            SKUP instruction = new SKUP(0);
+            SKUP instruction = new SKUP(KEYPAD_0);
             instruction.Execute(VM);
-            Tribble expectedPC = pc + (keyUp ? 2 : 0);
+            
+            return VM.PC;
+        }
 
-            Assert.That(VM.PC, Is.EqualTo(expectedPC));
+        [TestCase(true, ExpectedResult = 2)]
+        [TestCase(false, ExpectedResult = 0)]
+        public int SKPR(bool keyDown)
+        {
+            KeyOp(keyDown, WINKEY_1);
+
+            SKPR instruction = new SKPR(KEYPAD_0);
+            instruction.Execute(VM);
+
+            return VM.PC;
         }
 
         [Test]
         public void BCD()
         {
-
             VM.V[1] = 123;
 
             BCD instruction = new BCD(1);
             instruction.Execute(VM);
 
-            Tribble index = VM.I;
-
-            Assert.That(VM.RAM[index], Is.EqualTo(1));
-            Assert.That(VM.RAM[index + 1], Is.EqualTo(2));
-            Assert.That(VM.RAM[index + 2], Is.EqualTo(3));
+            Assert.That(VM.RAM[VM.I], Is.EqualTo(1));
+            Assert.That(VM.RAM[VM.I + 1], Is.EqualTo(2));
+            Assert.That(VM.RAM[VM.I + 2], Is.EqualTo(3));
         }
     }
 }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/InstructionSet.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/InstructionSet.cs
@@ -38,7 +38,7 @@ public static class InstructionSet
         _instructions.Add("JUMPI", (arguments) => new JUMPI(arguments));
         _instructions.Add("RAND", (arguments) => new RAND(arguments.HighNibble, arguments.LowByte));
         _instructions.Add("DRAW", (arguments) => new DRAW(arguments.HighNibble, arguments.MiddleNibble, arguments.LowNibble));
-        _instructions.Add("SKPR", (arguments) => new SKPR(arguments.HighNibble, arguments.LowByte));
+        _instructions.Add("SKPR", (arguments) => new SKPR(arguments.HighNibble));
         _instructions.Add("SKUP", (arguments) => new SKUP(arguments.HighNibble));
         _instructions.Add("MOVED", (arguments) => new MOVED(arguments.HighNibble));
         _instructions.Add("KEYD", (arguments) => new KEYD(arguments.HighNibble));

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/SKPR.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/SKPR.cs
@@ -1,7 +1,7 @@
 using CHIP_8_Virtual_Machine.InstructionBases;
 
 namespace CHIP_8_Virtual_Machine.Instructions;
-public class SKPR : RegisterWithValueInstruction
+public class SKPR : RegisterWithDiscriminatorInstruction
 {
     public override void Execute(VM vm)
     {
@@ -11,7 +11,7 @@ public class SKPR : RegisterWithValueInstruction
         }
     }
 
-    public SKPR(Register X, byte value)
-        : base(X, value) { }
+    public SKPR(Register X)
+        : base(X, 0x9E) { }
 
 }


### PR DESCRIPTION
I refactored the SKUP test to extract the key manipulation concern, changed the result evaluation to ExpectedResult; added an SKPR test; moved SKPR to RegisterWithDiscriminatorInstruction base and fixed up the constructor and the instruction set. 