### PR TITLE
Fix incorrect references to X which should be V[X] in instructions, fix issue in DisplaySprite method

### DIFF
--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/BlazorKeypadMap.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/BlazorKeypadMap.cs
@@ -1,0 +1,26 @@
+﻿namespace CHIP_8_Virtual_Machine
+{
+    public class BlazorKeypadMap : IKeypadMap
+    {
+        public IDictionary<string, Nibble> Map => new Dictionary<string, Nibble> {
+                    // map to standard Windows key names as chars
+                    // keypad square top left of keyboard
+                    { "1", 0x0 },
+                    { "2", 0x1 },
+                    { "3", 0x2 },
+                    { "4", 0x3 },
+                    { "Q", 0x4 },
+                    { "W", 0x5 },
+                    { "E", 0x6 },
+                    { "R", 0x7 },
+                    { "A", 0x8 },
+                    { "S", 0x9 },
+                    { "D", 0xA },
+                    { "F", 0xB },
+                    { "Z", 0xC },
+                    { "X", 0xD },
+                    { "C", 0xE },
+                    { "V", 0xF }
+                };
+    }
+}

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Display.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Display.cs
@@ -51,14 +51,15 @@ public class Display
                     if (localX >= DISPLAY_WIDTH || localY >= DISPLAY_HEIGHT) continue;
 
                     bool currentPixelState = _pixels[localX, localY];
-                    bool shouldDisplay = (spriteByte & (0x1 << j)) != 0; // checks if bit j is set
-                    if (currentPixelState && shouldDisplay)
+                    bool newPixelState = (spriteByte & (0x1 << j)) != 0; // checks if bit j is set
+
+                    if (currentPixelState && newPixelState)
                     {
                         pixelErased = true;
-                        shouldDisplay = false;
                     }
 
-                    _pixels[localX, localY] = shouldDisplay;
+
+                    _pixels[localX, localY] = currentPixelState ^ newPixelState;
                 }
             }
         }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/LDSPR.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/LDSPR.cs
@@ -5,7 +5,7 @@ public class LDSPR : RegisterInstruction
 {
     public override void Execute(VM vm)
     {
-        char c = (char)(((byte)X) + '0');
+        char c = (char)(((byte)vm.V[X]) + '0');
         vm.I = vm.SystemFont.AddressOf(c);
     }
 

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/LOADS.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/LOADS.cs
@@ -5,7 +5,7 @@ public class LOADS : RegisterInstruction
 {
     public override void Execute(VM vm)
     {
-        vm.SoundTimer.Start(X);
+        vm.SoundTimer.Start(vm.V[X]);
     }
 
     public LOADS(Register X)

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/READ.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/READ.cs
@@ -5,7 +5,7 @@ public class READ : RegisterInstruction
 {
     public override void Execute(VM vm)
     {
-        for (Nibble i = 0; i < X; i++)
+        for (Nibble i = 0; i <= X; i++)
         {
             vm.V[i] = vm.RAM[(Tribble)(vm.I + i)];
         }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/SKPR.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/SKPR.cs
@@ -5,7 +5,7 @@ public class SKPR : RegisterInstruction
 {
     public override void Execute(VM vm)
     {
-        if (vm.Keypad[X])
+        if (vm.Keypad[vm.V[X]])
         {
             vm.PC += 2;
         }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/SKUP.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/SKUP.cs
@@ -5,7 +5,7 @@ public class SKUP : RegisterInstruction
 {
     public override void Execute(VM vm)
     {
-        if (!vm.Keypad[X])
+        if (!vm.Keypad[vm.V[X]])
         {
             vm.PC += 2;
         }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/STOR.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Instructions/STOR.cs
@@ -5,7 +5,7 @@ public class STOR : RegisterInstruction
 {
     public override void Execute(VM vm)
     {
-        for (Nibble i = 0; i < X; i++)
+        for (Nibble i = 0; i <= X; i++)
         {
             vm.RAM[vm.I + i] = vm.V[i];
         }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/VM.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/VM.cs
@@ -146,7 +146,7 @@ namespace CHIP_8_Virtual_Machine
             }
             else
             {
-                ClockTick.Interval = 1;
+                ClockTick.Interval = 2;
                 ClockTick.Elapsed += (s,e) => Task.Run(InstructionCycle);
                 ClockTick.Elapsed += (s, e) => { if (_running) ClockTick.Start(); };
                 ClockTick.Start();

--- a/Chip-8 Challenge/src/Chip8-UI/Pages/Chip-8.razor
+++ b/Chip-8 Challenge/src/Chip8-UI/Pages/Chip-8.razor
@@ -27,7 +27,7 @@
 
     protected  override void OnInitialized()
     {
-        _vm = new VM(new WindowsKeypadMap());
+        _vm = new VM(new BlazorKeypadMap());
         _keypad = _vm.Keypad;
         _vm.Display.OnDisplayUpdated += DisplayUpdated;
 


### PR DESCRIPTION
Fix incorrect references to X which should be V[X] in instructions, fix issue in DisplaySprite method to ensure the display is set correctly when there is a clash