### PR TITLE
Resolve default vs additional keymap issue.

### DIFF
--- a/Chip-8 Challenge/src/CHIP-8 Console/Program.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Console/Program.cs
@@ -8,7 +8,8 @@ namespace CHIP_8_Console
         static void Main(string[] args)
         {
             Console.WriteLine("Will load PONG and run. Press CTRL+C at any time to quit.");
-            _vm = new VM(new WindowsKeypadMap());
+            _vm = new VM();
+            _vm.Keypad.MapKeys(new WindowsKeypadMap());
             ((IDebugVM)_vm).ReplaceTimers(new DebugTimer(_vm), new DebugTimer(_vm));
             _vm.Load("pong.rom");
             _vm.OnAfterExecution += OnAfterExecution;

--- a/Chip-8 Challenge/src/CHIP-8 Tests/Instructions/InstructionTestsBase.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Tests/Instructions/InstructionTestsBase.cs
@@ -7,7 +7,7 @@ namespace CHIP_8_Tests.Instructions
     [TestFixture]
     public abstract class InstructionTestsBase
     {
-        public string WINKEY_1 = "D1";
+        public string WINKEY_1 = "1";
         public Nibble KEYPAD_0 = 0;
 
         public VM VM { get; set; }
@@ -27,7 +27,7 @@ namespace CHIP_8_Tests.Instructions
         [SetUp]
         public void Setup()
         {
-            VM = new VM(new WindowsKeypadMap());
+            VM = new VM();
         }
     }
 }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Keypad/DefaultKeypadMap.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Keypad/DefaultKeypadMap.cs
@@ -1,9 +1,9 @@
 ﻿namespace CHIP_8_Virtual_Machine
 {
-    public class BlazorKeypadMap : IKeypadMap
+    public class DefaultKeypadMap : IKeypadMap
     {
         public IDictionary<string, Nibble> Map => new Dictionary<string, Nibble> {
-                    // map to standard Windows key names as chars
+                    // assume key code is the same as the key name
                     // keypad square top left of keyboard
                     { "1", 0x0 },
                     { "2", 0x1 },

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Keypad/Keypad.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/Keypad/Keypad.cs
@@ -69,13 +69,9 @@ namespace CHIP_8_Virtual_Machine
             }
         }
 
-        public Keypad()
+        public Keypad(IKeypadMap map)
         {
             _map = new Dictionary<string, Nibble>();
-        }
-
-        public Keypad(IKeypadMap map) : this()
-        {
             MapKeys(map);
         }
     }

--- a/Chip-8 Challenge/src/CHIP-8 Virtual Machine/VM.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Virtual Machine/VM.cs
@@ -40,12 +40,12 @@ namespace CHIP_8_Virtual_Machine
 
         public event EventHandler<ExecutionResult> OnAfterExecution;
 
-        public VM(IKeypadMap keypadMap = null)
+        public VM()
         {
             _ram = new RAM();
             _vregisters = new VRegisters();
             _stack = new Stack<Tribble>();
-            _keypad = new Keypad(keypadMap ?? new WindowsKeypadMap());
+            _keypad = new Keypad(new DefaultKeypadMap());
             _display = new Display(this);
             _delayTimer = new HardwareTimer();
             _soundTimer = new HardwareTimer();

--- a/Chip-8 Challenge/src/Chip8-UI/Pages/Home.razor
+++ b/Chip-8 Challenge/src/Chip8-UI/Pages/Home.razor
@@ -25,7 +25,7 @@
 
     protected override void OnInitialized()
     {
-        _vm = new VM(new BlazorKeypadMap());
+        _vm = new VM();
         _keypad = _vm.Keypad;
         _vm.Display.OnSpriteDisplayed += SpriteUpdated;
         _vm.Display.OnDisplayCleared += ClearDisplay;

--- a/Chip-8 Challenge/src/WPF_UI/MainWindow.xaml.cs
+++ b/Chip-8 Challenge/src/WPF_UI/MainWindow.xaml.cs
@@ -23,7 +23,8 @@ namespace Chip8.UI.Wpf
 
         public MainWindow()
         {
-            _vm = new VM(new WindowsKeypadMap());
+            _vm = new VM();
+            _vm.Keypad.MapKeys(new WindowsKeypadMap());
 
             KeyDown += MainWindow_KeyDown;
             KeyUp += MainWindow_KeyUp;


### PR DESCRIPTION
In an attempt to square the circle, I've made the Blazor-style map (assuming key codes == key name) the default at VM constructor time. Then, if you need a different mapping (for Windows apps for example) you can override with vm.Keypad.MapKeys(). This removes the tension over the constructor parameters while allowing for a genuine default that makes sense. It does mean Windows app clients need to remember to re-map the keys but I think making this intentional is probably better.

Thoughts?