### PR TITLE
Add mock IKeypadMap and use this when testing Instructions

### DIFF
--- a/Chip-8 Challenge/src/CHIP-8 Tests/CHIP-8 Tests.csproj
+++ b/Chip-8 Challenge/src/CHIP-8 Tests/CHIP-8 Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>

--- a/Chip-8 Challenge/src/CHIP-8 Tests/Instructions/InstructionTestsBase.cs
+++ b/Chip-8 Challenge/src/CHIP-8 Tests/Instructions/InstructionTestsBase.cs
@@ -1,14 +1,36 @@
-﻿using NUnit.Framework;
+﻿using Castle.Components.DictionaryAdapter;
+using NUnit.Framework;
 using CHIP_8_Virtual_Machine;
 using CHIP_8_Virtual_Machine.InstructionBases;
+using NSubstitute;
 
 namespace CHIP_8_Tests.Instructions
 {
     [TestFixture]
     public abstract class InstructionTestsBase
     {
-        public string WINKEY_1 = "D1";
+        public string WINKEY_1 = "1";
         public Nibble KEYPAD_0 = 0;
+
+        private IKeypadMap _keyboardMap;
+        private readonly IDictionary<string, Nibble> _mockKeyboardMapValues = new Dictionary<string, Nibble> {
+            { "1", 0x0 },
+            { "2", 0x1 },
+            { "3", 0x2 },
+            { "4", 0x3 },
+            { "Q", 0x4 },
+            { "W", 0x5 },
+            { "E", 0x6 },
+            { "R", 0x7 },
+            { "A", 0x8 },
+            { "S", 0x9 },
+            { "D", 0xA },
+            { "F", 0xB },
+            { "Z", 0xC },
+            { "X", 0xD },
+            { "C", 0xE },
+            { "V", 0xF }
+        };
 
         public VM VM { get; set; }
 
@@ -27,7 +49,12 @@ namespace CHIP_8_Tests.Instructions
         [SetUp]
         public void Setup()
         {
-            VM = new VM(new WindowsKeypadMap());
+            _keyboardMap = Substitute.For<IKeypadMap>();
+            _keyboardMap.Map.Returns(_mockKeyboardMapValues);
+
+            VM = new VM(_keyboardMap);
         }
+
+
     }
 }


### PR DESCRIPTION
Reference NSubstitute and use this to create a Mock IKeyboardMap interface and pass this into the VM when testing instructions, this decouples the instructions tests from the Windows Keymap implementation