### PR TITLE
Add MovePath to describe paths on the board

### DIFF
--- a/Chess Challenge/RMGChess.ConsoleApp/DisplaySettings.cs
+++ b/Chess Challenge/RMGChess.ConsoleApp/DisplaySettings.cs
@@ -6,7 +6,7 @@
         public const int BoardTop = 3;
         public const int PreviousMoveLine = 3;
         public const int RightHandBlockColumn = 31;
-        public const int NextMoveLine = 5;
+        public const int NextMoveLine = 7;
         public const int ErrorLine = 13;
         public const int PromptLine = 13;
         public const int MovesDisplayLine = 15;

--- a/Chess Challenge/RMGChess.ConsoleApp/Program.cs
+++ b/Chess Challenge/RMGChess.ConsoleApp/Program.cs
@@ -51,8 +51,9 @@ namespace RMGChess.ConsoleApp
                             #region show previous move
                             if (lastMove is not null)
                             {
-                                string previousMove = $"[blue]Previous move by {whoseTurn.Switch()}: {(Math.Ceiling(roundIndex) - 1)}. {lastMoveAsAlgebra} ({moveDescription(lastMove)})[/]";
-                                ChessConsole.Write(DisplaySettings.RightHandBlockColumn, DisplaySettings.PreviousMoveLine, previousMove, true);
+                                ChessConsole.Write(DisplaySettings.RightHandBlockColumn, DisplaySettings.PreviousMoveLine, $"Previous move by {whoseTurn.Switch()}.", true);
+                                ChessConsole.Write(DisplaySettings.RightHandBlockColumn, DisplaySettings.PreviousMoveLine + 1, $"[blue]Algebra: {(Math.Ceiling(roundIndex) - 1)}. {lastMoveAsAlgebra}[/]", true);
+                                ChessConsole.Write(DisplaySettings.RightHandBlockColumn, DisplaySettings.PreviousMoveLine + 2, $"[blue]{moveDescription(lastMove)}[/]", true);
                             }
                             else
                             {
@@ -64,12 +65,11 @@ namespace RMGChess.ConsoleApp
 
                             #region show next move
                             ChessConsole.WriteLine(DisplaySettings.RightHandBlockColumn, DisplaySettings.NextMoveLine, $"{whoseTurn} to play.");
-                            ChessConsole.WriteLine(DisplaySettings.RightHandBlockColumn, DisplaySettings.NextMoveLine + 1, $"Algebra: {(int)roundIndex}. {moveAsAlgebra}", true);
+                            ChessConsole.WriteLine(DisplaySettings.RightHandBlockColumn, DisplaySettings.NextMoveLine + 1, $"[green]Algebra: {(int)roundIndex}. {moveAsAlgebra}[/]", true);
                             roundIndex += 0.5f; // increment by half for each move
 
-                            ChessConsole.WriteLine(DisplaySettings.RightHandBlockColumn, DisplaySettings.NextMoveLine + 2, $"[green]Moving {moveDescription(move)}[/]", true);
+                            ChessConsole.WriteLine(DisplaySettings.RightHandBlockColumn, DisplaySettings.NextMoveLine + 2, $"[green]{moveDescription(move)}[/]", true);
                             bool animate = false;// mode is null;
-                            var steps = move.Path.Steps; // need to trigger debugging
                             DisplayBoard(game.Board, whoseTurn, move.From, move.To, animate);
 
                             #endregion
@@ -285,7 +285,22 @@ namespace RMGChess.ConsoleApp
 
                             string moveDescription(Move move)
                             {
-                                return $"{move.Piece} from {move.From} to {move.To}{(move.TakesPiece ? " taking " + move.PieceToTake : "")}{(move.IsPromotion ? " promotes to " + move.PromotesTo.Name : "")}";
+                                string output = null;
+                                if (move is CastlingMove castlingMove)
+                                {
+                                    Move rookMove = castlingMove.RookMove;
+                                    output = $"Castling {castlingMove.Side} {move.Piece} from {move.From} to {move.To} ({move.Path.ToString()}) and {rookMove.Piece} from {rookMove.From} to {rookMove.To} ({rookMove.Path.ToString()})";
+                                }
+                                else if (move is EnPassantMove)
+                                {
+                                    output = $"Moving {move.Piece} from {move.From} to {move.To} taking {move.PieceToTake} en passant ({move.Path.ToString()})";
+                                }
+                                else
+                                {
+                                    output = $"Moving {move.Piece} from {move.From} to {move.To}{(move.TakesPiece ? " taking " + move.PieceToTake : "")}{(move.IsPromotion ? " promotes to " + move.PromotesTo.Name : "")} ({move.Path.ToString()})";
+                                }
+
+                                return output;
                             }
                         },
                         (roundIndex, whoseTurn, move) =>

--- a/Chess Challenge/RMGChess.Core/Moves/CastlingMove.cs
+++ b/Chess Challenge/RMGChess.Core/Moves/CastlingMove.cs
@@ -5,6 +5,8 @@ namespace RMGChess.Core
 {
     public class CastlingMove : Move
     {
+        public Move RookMove { get; private set; }
+
         public static bool CanCastle(King king, Side side)
         {
             Rook rook = GetMovingRook(king, side);
@@ -53,7 +55,7 @@ namespace RMGChess.Core
         {
             Board board = game.Board;
             King king = Piece as King;
-            Rook rook = GetMovingRook(king, Side) as Rook;
+            Rook rook = RookMove.Piece as Rook;
 
             if (Piece.HasMoved)
             {
@@ -70,18 +72,8 @@ namespace RMGChess.Core
                 throw new InvalidMoveException("Cannot castle with a rook that has moved.");
             }
 
-            // identify position that the rook will move to
-            Position rookTo = Side switch
-            {
-                Side.Kingside => Piece.IsWhite ? "f1" : "f8",
-                Side.Queenside => Piece.IsWhite ? "d1" : "d8",
-                _ => throw new ShouldNeverHappenException("Invalid castling side.")
-            };
-
-            Move rookMove = new Move(rook, rook.Position, rookTo);
-
             base.Execute(game);
-            rookMove.Execute(game);
+            RookMove.Execute(game);
         }
 
         public CastlingMove(King king, Side type)
@@ -89,13 +81,18 @@ namespace RMGChess.Core
             Piece = king;
             Side = type;
             From = king.Position;
-            To = type switch
+            
+            (To, Position rookTo) = type switch
             {
-                Side.Kingside => king.IsWhite ? "g1" :"g8",
-                Side.Queenside => king.IsWhite ? "c1" : "c8",
+                Side.Kingside => king.IsWhite ? ("g1", "f1") : ("g8", "f8"),
+                Side.Queenside => king.IsWhite ? ("c1", "d1") : ("c8","d8"),
                 _ => throw new ShouldNeverHappenException("Invalid castling side.")
             };
+
             Direction = GetDirection(From, To);
+            Rook rook = GetMovingRook(king, Side) as Rook;
+            RookMove = new Move(rook, rook.Position, rookTo);
+            Path = new MovePath(From, To, Direction);
         }
     }
 }

--- a/Chess Challenge/RMGChess.Core/Moves/Move.cs
+++ b/Chess Challenge/RMGChess.Core/Moves/Move.cs
@@ -16,7 +16,6 @@ namespace RMGChess.Core
         public Piece PieceToTake { get; protected set; }
         public bool IsPromotion => Piece is Pawn && (To.Rank == (Piece.IsWhite ? 8 : 1) || To.Rank == (Piece.IsBlack ? 1 : 8));
         public Type PromotesTo { get; protected set; }
-        public bool PlacesOpponentKingInCheck { get; protected set; }
         public MovePath Path { get; protected set; }
 
         public override string ToString()
@@ -83,7 +82,7 @@ namespace RMGChess.Core
             throw new ChessException("Invalid move direction");
         }
 
-        public Move(Piece piece, Position from, Position to, Piece pieceToTake = null, Type promotesTo = null, bool placesOpponentKingInCheck = false)
+        public Move(Piece piece, Position from, Position to, Piece pieceToTake = null, Type promotesTo = null)
         {
             Piece = piece;
             From = from;
@@ -92,7 +91,6 @@ namespace RMGChess.Core
             Direction = GetDirection(from, to);
             Path = new MovePath(from, to, Direction);
             PromotesTo = promotesTo; // can be null even if IsPromotion is true
-            PlacesOpponentKingInCheck = placesOpponentKingInCheck;
         }
 
         protected Move()

--- a/Chess Challenge/RMGChess.Core/Moves/MovePath.cs
+++ b/Chess Challenge/RMGChess.Core/Moves/MovePath.cs
@@ -20,9 +20,9 @@ namespace RMGChess.Core
             string output = "";
             foreach (Position step in Steps)
             {
-                output += $"{step} -> ";
+                output += $"{step}->";
             }
-            return output[..^4];
+            return output[..^2];
         }
 
         private IEnumerable<Position> GetSteps()


### PR DESCRIPTION
I created a MovePath class which contains all the steps a piece will take moving from From to To. I added a property of this type to the Move class, and refactored the CastlingMove class to handle it and also offer the rook move as a property RookMove so you can see the paths of both. 

I updated the test program to show the paths each move will take.

This is to prepare for the implementation of check mechanics, which will require path prediction. I thought this was simple enough for me to do it to let us focus on the meat of the work on Monday (spoiler: our existing design doesn't work very well for this!).